### PR TITLE
fixed exponential growth of the itemStack

### DIFF
--- a/src/main/java/software/bernie/techarium/util/ChancedItemStackList.java
+++ b/src/main/java/software/bernie/techarium/util/ChancedItemStackList.java
@@ -78,7 +78,7 @@ public class ChancedItemStackList {
         cachedOutput = new ArrayList<>();
         for (ChancedItemStack stack : stackList) {
             if (stack.roll()) {
-                cachedOutput.add(stack.getStack());
+                cachedOutput.add(stack.getStack().copy());
             }
         }
         Techarium.LOGGER.info("Cached Output: " + cachedOutput);


### PR DESCRIPTION
This happened, because the insertItem manipulated the stack. Only expose the copy of the itemStack if you need to be sure, that it is not manipulated